### PR TITLE
Fix expectation format for array query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Php client and behat context for [MockServer](https://www.mock-server.com/).
 
 ## Install
 
+From [Packagist](https://packagist.org/packages/lequipefr/mockserver-behat-context):
+
 ``` bash
 composer require --dev lequipefr/mockserver-behat-context
 ```

--- a/features/expectations.feature
+++ b/features/expectations.feature
@@ -342,12 +342,8 @@ Feature: Expectations
                             "values": ["val"]
                         },
                         {
-                            "name": "scopes[0]",
-                            "values": ["basics"]
-                        },
-                        {
-                            "name": "scopes[1]",
-                            "values": ["optins"]
+                            "name": "scopes[]",
+                            "values": ["basics", "optins"]
                         },
                         {
                             "name": "array[key]",


### PR DESCRIPTION
Creating an expectation for `/path?scopes[]=basics&scopes[]=optins` does not match with a request with same parameters.